### PR TITLE
Fixed inheritance_pattern example error

### DIFF
--- a/partials/10_inheritance_pattern.html
+++ b/partials/10_inheritance_pattern.html
@@ -36,10 +36,10 @@ var NotesController = BaseController.extend({
 	_notesModel:null,
 	
 	init:function($scope,NotesModel,Notifications,$route){
-		this._super($scope)
 		this._notifications = Notifications;
 		this._notesModel = NotesModel;
 		this._notesModel.loadSlides();
+		this._super($scope);
 	},
 
 	defineListeners:function(){


### PR DESCRIPTION
In Classes that extends BaseController:

this._super($scope) in the init function should be ran last, because if it is ran first, it will run the ExtendedController's defineScope / defineListener function before the init function has bind the injected services.
